### PR TITLE
Fix: setup-node action syntax, reffered to v3.0.0 release note

### DIFF
--- a/.github/workflows/secretlint.yml
+++ b/.github/workflows/secretlint.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node_version: 16
+          node-version: 16
       - name: Install
         run: npm install
       - name: Lint with Secretlint


### PR DESCRIPTION
See https://github.com/actions/setup-node/releases/tag/v3.0.0